### PR TITLE
Point to the compiled version for the importer

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fuzzy-match-utils",
   "version": "1.1.0",
   "description": "A collection of string matching algorithms built with React Select in mind",
-  "main": "src/main.js",
+  "main": "dist/fuzzy-match-utils.js",
   "scripts": {
     "prepublish": ". ./prepublish.sh",
     "lint": "eslint src",


### PR DESCRIPTION
Right now, it points to the src file which includes Flow types, which requires the loader to know flow.  Instead, point the loader to the dist build.