### PR TITLE
Preferential match included strings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -84,16 +84,12 @@ export function typeaheadSimilarity(a: string, b: string): number {
         [a, b] = [b, a];
     }
 
-    // Early exit if `a` startsWith `b`; these will be scored higher than any
+    // Early exit if `a` includes `b`; these will be scored higher than any
     // other options with the same `b` (filter string), with a preference for
     // shorter `a` strings (option labels).
-    if (a.indexOf(b) === 0) {
+    if (a.indexOf(b) !== -1) {
         return bLength + 1 / aLength;
     }
-
-    // TODO(riley): It would be nice if subsequence *proximity* was factored
-    //              in. For example, a filter string of "AL" should match
-    //              "wALnut grove" before it matches "wAtsonviLle"
 
     // Initialize the table axes:
     //


### PR DESCRIPTION
It can be tricky, with the current fuzzy matching, to do non-fuzzy
sorting. For example, searching a bank of components for 'icon'
will find many results, very few of which are the ones you want.

Preferential treatment was given for finding strings that started
with a given string; this PR extends that preference for any
substring, regardless of its position in the target.

----

@rileyjshaw I saw you had a TODO to do something similar. My
change is probably much less elegant than what you had in mind,
but in my experience it works well. Including some screenshots
showcasing the new behaviour:

<img width="637" alt="screen shot 2017-04-23 at 2 21 54 pm" src="https://cloud.githubusercontent.com/assets/6692932/25316241/57f87b24-2831-11e7-9871-ee3d0b9ff805.png">
<img width="627" alt="screen shot 2017-04-23 at 2 22 20 pm" src="https://cloud.githubusercontent.com/assets/6692932/25316242/594d32bc-2831-11e7-857b-32eaad0bf92d.png">
<img width="630" alt="screen shot 2017-04-23 at 2 22 36 pm" src="https://cloud.githubusercontent.com/assets/6692932/25316243/5aa19680-2831-11e7-9bf0-7845296f0e21.png">
